### PR TITLE
Automate the release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+on:
+  push:
+    branches: [master, main]
+    tags: ["*"]
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - uses: olafurpg/setup-scala@v10
+      - uses: olafurpg/setup-gpg@v3
+      - run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/build.sbt
+++ b/build.sbt
@@ -20,15 +20,6 @@ scmInfo := Some(
   )
 )
 
-publishTo := {
-  Some(
-    if (isSnapshot.value)
-      Opts.resolver.sonatypeSnapshots
-    else
-      Opts.resolver.sonatypeStaging
-  )
-}
-publishMavenStyle := true
 publishArtifact in Test := false
 pomIncludeRepository := { _ =>
   false
@@ -41,24 +32,3 @@ pomExtra :=
       <url>http://github.com/yannmoisan</url>
     </developer>
   </developers>
-
-publishTo := sonatypePublishToBundle.value
-
-import sbtrelease.ReleaseStateTransformations._
-
-releaseCrossBuild := true
-
-releaseProcess := Seq[ReleaseStep](
-  checkSnapshotDependencies,
-  inquireVersions,
-  runClean,
-  runTest,
-  setReleaseVersion,
-  commitReleaseVersion,
-  tagRelease,
-  releaseStepCommandAndRemaining("+publishSigned"),
-  releaseStepCommand("sonatypeBundleRelease"),
-  setNextVersion,
-  commitNextVersion,
-  pushChanges
-)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,4 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.17")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
-
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")
-
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.6")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.1-SNAPSHOT"


### PR DESCRIPTION
- The _release_ process is handled by [sbt-ci-release](https://github.com/olafurpg/sbt-ci-release)
- a workflow is configured to trigger automatically `sbt ci-release`